### PR TITLE
Add a workflow to validate the tests using the reference emulator.

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,40 @@
+name: Validate
+
+on:
+  push:
+    paths:
+    - '.github/workflows/validate.yml'
+    - 'v1/*.json'
+  pull_request:
+    paths:
+    - '.github/workflows/validate.yml'
+    - 'v1/*.json'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2'
+
+    - name: Install dependencies
+      run: |
+        curl -L curl -L https://zxe.io/scripts/add-zxe-apt-repo.sh | sudo sh
+        sudo apt-get -y install libz80-dev
+        gem install z80
+
+    - name: Download runner
+      run: |
+        curl -L $(
+          curl -s https://api.github.com/repos/redcode/run-jsmoo-z80-test/releases/latest |
+          grep tar.xz\" | grep browser_download_url | cut -d : -f 2,3 | tr -d '" '
+        ) | xz -cd | tar --strip-components=1 -xf -
+
+    - name: Run tests
+      run:
+        ./run-jsmoo-z80-test v1/*.json

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,5 @@
+[![](https://github.com/SingleStepTests/z80/actions/workflows/validate.yml/badge.svg)](https://github.com/SingleStepTests/z80/actions/workflows/validate.yml)
+
 Very quick overview
 
 Each .json file represents an instruction sequence. Each one contains 1000 tests in this format:


### PR DESCRIPTION
This tiny PR adds a workflow to validate the v1 tests on an Ubuntu runner. It installs [libz80](https://github.com/redcode/Z80), Ruby and the [z80](https://github.com/redcode/Z80-Ruby) gem. Then it downloads the latest version of [`run-jsmoo-z80-test`](https://github.com/redcode/run-jsmoo-z80-test) and finally runs all tests to make sure there are no discrepancies with the reference emulator.