### PR TITLE
Fix: Use the values of the inputs fields to generate the tests

### DIFF
--- a/generation/generation.js
+++ b/generation/generation.js
@@ -4,7 +4,7 @@ var seed_input, numtests_input;
 window.onload = function() {
     seed_input = document.getElementById('seed');
     dconsole = new dct();
-    seed_input.value = "apples and oranges";
+    seed_input.value = "yo";
     numtests_input = document.getElementById('numtests');
     numtests_input.value = '1000';
 }
@@ -16,7 +16,6 @@ class dct {
 
     addl(order, what) {
         console.log('LOG:', what);
-        this.el.innerHTML = what;
     }
 }
 var dconsole;
@@ -40,5 +39,6 @@ function click_generate_z80_tests() {
     Z80_DO_FULL_MEMCYCLES = !simplified_mem;
     Z80_DO_MEM_REFRESHES = refresh; // Put I/R on address bus
     Z80_NULL_WAIT_STATES = nullwaits;
+    Z80_NUM_TO_GENERATE = numtests;
     generate_Z80_tests(seed, CMOS);
 }

--- a/generation/z80_test_generator.js
+++ b/generation/z80_test_generator.js
@@ -2479,10 +2479,9 @@ class Z80_test_generator {
     }
 }
 
-function generate_Z80_tests(seed=null, CMOS) {
+function generate_Z80_tests(seed, CMOS) {
     console.log('FULL MEMCYCLES?', Z80_DO_FULL_MEMCYCLES);
-    if (seed !== null) rand_seed = seed;
-    rand_seed = 'yo';
+    rand_seed = seed;
     let os1 = new Uint8Array(1);
     let os2 = new Uint8Array(2);
     let os4 = new Uint8Array(4);


### PR DESCRIPTION
The current version completely ignores the values passed in the two inputs fields, for the seed and the number of tests to generate.

This PR fixes this as well as a crach caused by: https://github.com/SingleStepTests/z80/blob/f8b2a84e1b4f4c96ba6e0950abb9b017467d47e6/generation/generation.js#L19

The default value for the seed in the input field has been change, so that the default settings generates the same tests as the current ones.